### PR TITLE
UX add back 'open link in new tab' in the right click on links menu 

### DIFF
--- a/header.js
+++ b/header.js
@@ -168,6 +168,7 @@ view Nav {
   }
 
   const routeProps = path => ({
+    href: path,
     onClick: router.link(path),
     className: { active: router.isActive(path) }
   })


### PR DESCRIPTION
Right clicking on the `Docs` and `Examples` links at the home page

Before:
<img width="397" alt="without" src="https://cloud.githubusercontent.com/assets/847572/12217784/952c6c5c-b713-11e5-8551-cea9ee18cf3c.png">

After:
<img width="410" alt="link" src="https://cloud.githubusercontent.com/assets/847572/12217789/cc13e3da-b713-11e5-91a5-0e1c0ede23c4.png">
